### PR TITLE
Fix double-encoding of cast attributes during merge

### DIFF
--- a/src/RecordMerge.php
+++ b/src/RecordMerge.php
@@ -228,8 +228,10 @@ class RecordMerge
                 continue;
             }
 
-            // Set the attribute on the target model.
-            $this->target->{$key} = $value;
+            // Use getAttribute() to read the cast value from the source model,
+            // so that cast attributes (e.g. JSON) are not double-encoded
+            // when set through the target model's setter.
+            $this->target->{$key} = $this->source->getAttribute($key);
         }
 
         // Save the target model with the merged attributes.


### PR DESCRIPTION
## Summary

- `mergeAttributes()` used raw database values from `getAttributes()` and assigned them via the Eloquent property setter, which re-applies casts. For JSON-cast columns this caused double-encoding (e.g. `'["foo"]'` became `'[\"foo\"]'`).
- Fixed by reading values through `getAttribute()` (cast-aware) so the target's setter encodes them correctly.
- Affects all cast attributes (JSON, encrypted, custom casts), not just JSON columns.

## Test plan

- [ ] Merge two models where the source has a JSON-cast attribute with a value and the target has `null` — verify the merged value is a proper JSON array, not a double-encoded string
- [ ] Merge two models where both have JSON-cast attributes set — verify the target's value is preserved (not overwritten)
- [ ] Merge models with non-cast attributes — verify behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)