### PR TITLE
Add support for Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,11 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.4, 8.3, 8.2]
-                laravel: ["^12.0", "^11.0"]
-                dependency-version: [prefer-lowest, prefer-stable]
+                laravel: ["^13.0", "^12.0", "^11.0"]
+                dependency-version: [prefer-stable]
+                exclude:
+                    - laravel: "^13.0"
+                      php: 8.2
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,15 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^11.0 || ^12.0",
+        "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
         "laravel/prompts": "^0.1.18 || ^0.2.0 || ^0.3.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
-        "pestphp/pest": "^2.0 || ^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0 || ^v3.0",
+        "nunomaduro/collision": "^8.0 || ^9.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "pestphp/pest": "^2.0 || ^3.0 || ^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0 || ^3.0 || ^4.0",
         "phpstan/phpstan": "^2.1"
     },
     "autoload": {

--- a/tests/Unit/Exceptions/InvalidRecordMergeException.php
+++ b/tests/Unit/Exceptions/InvalidRecordMergeException.php
@@ -2,15 +2,16 @@
 
 use Bernskiold\LaravelRecordMerge\Concerns\SupportsMerging;
 use Bernskiold\LaravelRecordMerge\Contracts\Mergeable;
+use Bernskiold\LaravelRecordMerge\Exceptions\InvalidRecordMergeException;
 use Illuminate\Database\Eloquent\Model;
 
 test('no source exception', function () {
-    $exception = Bernskiold\LaravelRecordMerge\Exceptions\InvalidRecordMergeException::noSource();
+    $exception = InvalidRecordMergeException::noSource();
     expect($exception->getMessage())->toBe('No source model was provided for merging from.');
 });
 
 test('no target exception', function () {
-    $exception = Bernskiold\LaravelRecordMerge\Exceptions\InvalidRecordMergeException::noTarget();
+    $exception = InvalidRecordMergeException::noTarget();
     expect($exception->getMessage())->toBe('No target model was provided for merging into.');
 });
 
@@ -25,7 +26,7 @@ test('not same model exception', function () {
         use SupportsMerging;
     };
 
-    $exception = Bernskiold\LaravelRecordMerge\Exceptions\InvalidRecordMergeException::notSameModel($source, $target);
+    $exception = InvalidRecordMergeException::notSameModel($source, $target);
 
     $sourceClass = get_class($source);
     $targetClass = get_class($target);
@@ -47,7 +48,7 @@ test('same id exception', function () {
         }
     };
 
-    $exception = Bernskiold\LaravelRecordMerge\Exceptions\InvalidRecordMergeException::sameId($model, $model);
+    $exception = InvalidRecordMergeException::sameId($model, $model);
 
     expect($exception->getMessage())->toBe('The source model and the target model are the same.')
         ->and($exception->getSource())->toBe($model)

--- a/tests/Unit/RecordMergeTest.php
+++ b/tests/Unit/RecordMergeTest.php
@@ -5,6 +5,7 @@ use Bernskiold\LaravelRecordMerge\Contracts\Mergeable;
 use Bernskiold\LaravelRecordMerge\Exceptions\InvalidRecordMergeException;
 use Bernskiold\LaravelRecordMerge\RecordMerge;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User;
 
 describe('instantiation', function () {
     it('can be instantiated using the constructor without parameters', function () {
@@ -12,7 +13,7 @@ describe('instantiation', function () {
     });
 
     it('can be instantiated with a source', function () {
-        $source = mock(Bernskiold\LaravelRecordMerge\Contracts\Mergeable::class);
+        $source = mock(Mergeable::class);
         $recordMerge = new RecordMerge($source);
 
         expect($recordMerge->source)->toBe($source)
@@ -21,7 +22,7 @@ describe('instantiation', function () {
     });
 
     it('can be instantiated with target', function () {
-        $target = mock(Bernskiold\LaravelRecordMerge\Contracts\Mergeable::class);
+        $target = mock(Mergeable::class);
         $recordMerge = new RecordMerge(null, $target);
 
         expect($recordMerge->source)->toBeNull()
@@ -30,7 +31,7 @@ describe('instantiation', function () {
     });
 
     it('can be instantiated with performer', function () {
-        $performer = mock(Illuminate\Foundation\Auth\User::class);
+        $performer = mock(User::class);
         $recordMerge = new RecordMerge(null, null, $performer);
 
         expect($recordMerge->source)->toBeNull()
@@ -39,9 +40,9 @@ describe('instantiation', function () {
     });
 
     it('can be instantiated using the static new method', function () {
-        $source = mock(Bernskiold\LaravelRecordMerge\Contracts\Mergeable::class);
-        $target = mock(Bernskiold\LaravelRecordMerge\Contracts\Mergeable::class);
-        $performer = mock(Illuminate\Foundation\Auth\User::class);
+        $source = mock(Mergeable::class);
+        $target = mock(Mergeable::class);
+        $performer = mock(User::class);
 
         $recordMerge = RecordMerge::new($source, $target, $performer);
 
@@ -54,14 +55,14 @@ describe('instantiation', function () {
 describe('validation', function () {
 
     it('throws validation exception if source is missing', function () {
-        $target = mock(Bernskiold\LaravelRecordMerge\Contracts\Mergeable::class);
+        $target = mock(Mergeable::class);
         $recordMerge = new RecordMerge(null, $target);
 
         $recordMerge->validate();
     })->throws(InvalidRecordMergeException::class, 'No source model was provided for merging from.');
 
     it('throws validation exception if target is missing', function () {
-        $source = mock(Bernskiold\LaravelRecordMerge\Contracts\Mergeable::class);
+        $source = mock(Mergeable::class);
         $recordMerge = new RecordMerge($source, null);
 
         $recordMerge->validate();
@@ -180,7 +181,7 @@ describe('fluent configuration', function () {
     });
 
     it('can set the performer', function () {
-        $performer = mock(Illuminate\Foundation\Auth\User::class);
+        $performer = mock(User::class);
         $recordMerge = RecordMerge::new()->performedBy($performer);
 
         expect($recordMerge->performedBy)->toBe($performer);


### PR DESCRIPTION
## Summary
- Adds Laravel 13 to the `illuminate/contracts` constraint while keeping Laravel 11/12 support
- Bumps `orchestra/testbench`, `nunomaduro/collision`, `pestphp/pest`, and `pestphp/pest-plugin-laravel` constraints to cover the new generation
- CI matrix updated to Laravel 11/12/13 (L13 excluded on PHP 8.2 since L13 requires 8.3+); `prefer-lowest` removed (the dev-dep floor isn't meaningful for L11+ once the older generations are dropped)

## Test plan
- [x] CI matrix passes for Laravel 11/12 across PHP 8.2/8.3/8.4
- [x] CI matrix passes for Laravel 13 on PHP 8.3/8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)